### PR TITLE
feat: generate env secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ centrifugo
 *.tar.gz
 *.env
 *.http
+/static

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "omnect-ui"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "actix-files",
  "actix-multipart",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,6 +1814,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -2501,7 +2502,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix 1.0.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2717,6 +2718,15 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+dependencies = [
+ "getrandom 0.3.2",
+]
 
 [[package]]
 name = "v_htmlescape"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 name = "omnect-ui"
 readme = "README.md"
 repository = "git@github.com:omnect/omnect-ui.git"
-version = "0.7.1"
+version = "0.8.0"
 build = "src/build.rs"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,9 @@ tokio = { version = "1.0", default-features = false, features = [
   "net",
   "process",
 ] }
+uuid = { version = "1.16", default-features = false, features = [
+  "v4",
+] }
 
 [features]
 mock = []

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,10 @@ COPY --from=distroless /var/lib/dpkg/status.d /distroless_pkgs
 
 RUN cargo new /work/omnect-ui
 
+COPY .git ./omnect-ui/.git
 COPY Cargo.lock ./omnect-ui/Cargo.lock
 COPY Cargo.toml ./omnect-ui/Cargo.toml
+COPY src/build.rs ./omnect-ui/src/build.rs
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry cd omnect-ui && cargo build ${OMNECT_UI_BUILD_ARG} --release --target-dir ./build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,6 @@ COPY --from=distroless /var/lib/dpkg/status.d /distroless_pkgs
 
 RUN cargo new /work/omnect-ui
 
-COPY .git ./omnect-ui/.git
 COPY Cargo.lock ./omnect-ui/Cargo.lock
 COPY Cargo.toml ./omnect-ui/Cargo.toml
 COPY src/build.rs ./omnect-ui/src/build.rs
@@ -43,6 +42,7 @@ COPY src/build.rs ./omnect-ui/src/build.rs
 RUN --mount=type=cache,target=/usr/local/cargo/registry cd omnect-ui && cargo build ${OMNECT_UI_BUILD_ARG} --release --target-dir ./build
 
 COPY src/* ./omnect-ui/src/
+COPY .git ./omnect-ui/.git
 RUN --mount=type=cache,target=/usr/local/cargo/registry <<EOF
   set -e
   # update timestamps to force a new build

--- a/build-and-run-image.sh
+++ b/build-and-run-image.sh
@@ -26,8 +26,6 @@ docker run --rm \
   -e SOCKET_PATH=/socket/api.sock \
   -e LOGIN_USER=omnect-ui \
   -e LOGIN_PASSWORD=123 \
-  -e CENTRIFUGO_CLIENT_TOKEN_HMAC_SECRET_KEY=my-token-secret-key \
-  -e CENTRIFUGO_HTTP_API_KEY=my-api-key \
   -e CENTRIFUGO_CLIENT_ALLOWED_ORIGINS="https://$(hostname | tr [:upper:] [:lower:]):"${omnect_ui_port}" https://localhost:"${omnect_ui_port}"" \
   -e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_ALLOW_SUBSCRIBE_FOR_CLIENT=true \
   -e CENTRIFUGO_CHANNEL_WITHOUT_NAMESPACE_ALLOW_HISTORY_FOR_CLIENT=true \

--- a/build-arm64-image.sh
+++ b/build-arm64-image.sh
@@ -9,4 +9,4 @@ docker buildx build \
   --platform   linux/arm64 \
   --load \
   -f Dockerfile . \
-  -t omnect-ui-arm64:"local_${omnect_ui_version}"
+  -t omnectshareddevacr.azurecr.io/omnect-ui:rst

--- a/build-arm64-image.sh
+++ b/build-arm64-image.sh
@@ -6,7 +6,7 @@ omnect_ui_version=$(toml get --raw Cargo.toml package.version)
 docker buildx build \
   --build-arg=DOCKER_NAMESPACE=omnectweucopsacr.azurecr.io \
   --build-arg=VERSION_RUST_CONTAINER=1.84.1-bookworm \
-  --platform   linux/arm64 \
+  --platform linux/arm64 \
   --load \
   -f Dockerfile . \
-  -t omnectshareddevacr.azurecr.io/omnect-ui:rst
+  -t omnectshareddevacr.azurecr.io/omnect-ui:$(whoami)

--- a/src/api.rs
+++ b/src/api.rs
@@ -61,6 +61,7 @@ pub enum FactoryResetMode {
     Mode4 = 4,
 }
 
+#[derive(Clone)]
 pub struct Api {
     ods_socket_path: String,
     update_os_path: String,
@@ -78,25 +79,17 @@ impl Api {
         username: &str,
         password: &str,
         index_html: &Path,
-    ) -> Result<Self> {
+    ) -> Self {
         debug!("Api::new() called");
 
-        let _ = fs::exists(ods_socket_path).context(format!(
-            "omnect device service socket file {ods_socket_path} does not exist"
-        ));
-
-        let _ = fs::exists(update_os_path).context(format!(
-            "path {update_os_path} for os update does not exist"
-        ));
-
-        Ok(Self {
+        Self {
             ods_socket_path: ods_socket_path.into(),
             update_os_path: update_os_path.into(),
             centrifugo_client_token_hmac_secret_key: centrifugo_client_token_hmac_secret_key.into(),
             username: username.into(),
             password: password.into(),
             index_html: index_html.into(),
-        })
+        }
     }
 
     pub async fn index(config: web::Data<Api>) -> actix_web::Result<NamedFile> {

--- a/src/api.rs
+++ b/src/api.rs
@@ -63,35 +63,15 @@ pub enum FactoryResetMode {
 
 #[derive(Clone)]
 pub struct Api {
-    ods_socket_path: String,
-    update_os_path: String,
+    pub ods_socket_path: String,
+    pub update_os_path: String,
     pub centrifugo_client_token_hmac_secret_key: String,
     pub username: String,
     pub password: String,
-    index_html: PathBuf,
+    pub index_html: PathBuf,
 }
 
 impl Api {
-    pub fn new(
-        ods_socket_path: &str,
-        update_os_path: &str,
-        centrifugo_client_token_hmac_secret_key: &str,
-        username: &str,
-        password: &str,
-        index_html: &Path,
-    ) -> Self {
-        debug!("Api::new() called");
-
-        Self {
-            ods_socket_path: ods_socket_path.into(),
-            update_os_path: update_os_path.into(),
-            centrifugo_client_token_hmac_secret_key: centrifugo_client_token_hmac_secret_key.into(),
-            username: username.into(),
-            password: password.into(),
-            index_html: index_html.into(),
-        }
-    }
-
     pub async fn index(config: web::Data<Api>) -> actix_web::Result<NamedFile> {
         debug!("index() called");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -348,13 +348,6 @@ async fn send_publish_endpoint(
     centrifugo_http_api_key: &str,
     ods_socket_path: &str,
 ) -> impl Responder {
-    #[cfg(not(feature = "mock"))]
-    let iotedge_modulegenerationid =
-        std::env::var("IOTEDGE_MODULEGENERATIONID").expect("IOTEDGE_MODULEGENERATIONID missing");
-
-    #[cfg(feature = "mock")]
-    let iotedge_modulegenerationid = "omnect-ui";
-
     let headers = vec![
         HeaderKeyValue {
             name: String::from("Content-Type"),
@@ -367,7 +360,7 @@ async fn send_publish_endpoint(
     ];
 
     let body = PublishIdEndpoint {
-        id: iotedge_modulegenerationid,
+        id: String::from(env!("CARGO_PKG_NAME")),
         endpoint: PublishEndpoint {
             url: format!(
                 "https://localhost:{}/api/publish",

--- a/vue/package.json
+++ b/vue/package.json
@@ -6,6 +6,7 @@
 	"scripts": {
 		"dev": "vite",
 		"build": "vite build --base=/static",
+		"build-dev": "vite build --base=/static --outDir=../static/ --emptyOutDir",
 		"tsc": "vue-tsc -b",
 		"preview": "vite preview",
 		"lint": "biome check .",


### PR DESCRIPTION
Secrets for centrifugo (api key and hmac key) will be generated on startup. API key and endpoint will be send to omnect device service.
The port for centrifugo is now optional, but by default 8000.

The git short rev will be now set correctly.
An option to build frontend for local test has been added.