### PR TITLE
fix(clippy): resolve pedantic and nursery warnings from Rust 1.95

### DIFF
--- a/src/app/src/update/device/network/form.rs
+++ b/src/app/src/update/device/network/form.rs
@@ -149,7 +149,7 @@ mod tests {
             let adapter = create_test_network_adapter("eth0", "192.168.1.100", false);
             let mut model = Model {
                 network_status: Some(NetworkStatus {
-                    network_status: vec![adapter.clone()],
+                    network_status: vec![adapter],
                 }),
                 ..Default::default()
             };
@@ -221,7 +221,7 @@ mod tests {
                 network_form_state: NetworkFormState::Editing {
                     adapter_name: "eth0".to_string(),
                     form_data: original_data.clone(),
-                    original_data: original_data.clone(),
+                    original_data,
                     errors: HashMap::new(),
                 },
                 network_form_dirty: false,
@@ -301,7 +301,7 @@ mod tests {
                 network_form_state: NetworkFormState::Editing {
                     adapter_name: "eth0".to_string(),
                     form_data: eth0_data.clone(),
-                    original_data: eth0_data.clone(),
+                    original_data: eth0_data,
                     errors: HashMap::new(),
                 },
                 network_form_dirty: false,
@@ -374,7 +374,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let mut changed_data = original_data.clone();
+            let mut changed_data = original_data;
             changed_data.ip_address = "192.168.1.101".to_string();
 
             let _ = handle_network_form_update(

--- a/src/app/src/update/device/network/verification.rs
+++ b/src/app/src/update/device/network/verification.rs
@@ -291,7 +291,7 @@ mod tests {
         fn tick_skips_polling_when_switching_to_dhcp() {
             let mut model = Model {
                 network_change_state: NetworkChangeState::WaitingForNewIp {
-                    new_ip: "".to_string(),
+                    new_ip: String::new(),
                     old_ip: "192.168.1.100".to_string(),
                     attempt: 0,
                     rollback_timeout_seconds: 60,

--- a/src/app/src/update/device/reconnection.rs
+++ b/src/app/src/update/device/reconnection.rs
@@ -223,32 +223,28 @@ fn advance_network_change_state(
     match &model.network_change_state {
         NetworkChangeState::WaitingForNewIp {
             new_ip, ui_port, ..
-        } => {
-            if result.is_ok() {
-                // Clone values before reassigning state to avoid borrow conflict
-                let new_ip = new_ip.clone();
-                let port = *ui_port;
-                model.network_change_state = NetworkChangeState::NewIpReachable {
-                    new_ip: new_ip.clone(),
-                    ui_port: port,
-                };
-                model.success_message = None;
-                model.error_message = None;
-                model.overlay_spinner = OverlaySpinnerState::new("Network settings applied")
-                    .with_text(format!("Redirecting to new IP: {new_ip}:{port}"));
-            }
+        } if result.is_ok() => {
+            // Clone values before reassigning state to avoid borrow conflict
+            let new_ip = new_ip.clone();
+            let port = *ui_port;
+            model.network_change_state = NetworkChangeState::NewIpReachable {
+                new_ip: new_ip.clone(),
+                ui_port: port,
+            };
+            model.success_message = None;
+            model.error_message = None;
+            model.overlay_spinner = OverlaySpinnerState::new("Network settings applied")
+                .with_text(format!("Redirecting to new IP: {new_ip}:{port}"));
         }
-        NetworkChangeState::WaitingForOldIp { .. } => {
-            if result.is_ok() {
-                // Old IP is reachable — rollback successful.
-                // No success message here: the "Network Settings Rolled Back" modal
-                // is triggered by the `network_rollback_occurred` flag in the healthcheck response.
-                model.network_change_state = NetworkChangeState::Idle;
-                model.overlay_spinner.clear();
-                model.invalidate_session();
-                model.success_message = None;
-                model.error_message = None;
-            }
+        NetworkChangeState::WaitingForOldIp { .. } if result.is_ok() => {
+            // Old IP is reachable — rollback successful.
+            // No success message here: the "Network Settings Rolled Back" modal
+            // is triggered by the `network_rollback_occurred` flag in the healthcheck response.
+            model.network_change_state = NetworkChangeState::Idle;
+            model.overlay_spinner.clear();
+            model.invalidate_session();
+            model.success_message = None;
+            model.error_message = None;
         }
         _ => {}
     }

--- a/src/app/src/update/wifi.rs
+++ b/src/app/src/update/wifi.rs
@@ -204,7 +204,7 @@ pub fn handle(event: WifiEvent, model: &mut Model) -> Command<Effect, Event> {
                             }
                             // Sort by RSSI descending (strongest first)
                             let mut networks: Vec<WifiNetwork> = best.into_values().collect();
-                            networks.sort_by(|a, b| b.rssi.cmp(&a.rssi));
+                            networks.sort_by_key(|n| std::cmp::Reverse(n.rssi));
 
                             *scan_results = networks;
                             *scan_state = WifiScanState::Finished;
@@ -765,7 +765,7 @@ mod tests {
             let _ = handle(
                 WifiEvent::Connect {
                     ssid: "MyNet".to_string(),
-                    password: "".to_string(),
+                    password: String::new(),
                 },
                 &mut model,
             );
@@ -933,7 +933,7 @@ mod tests {
                     },
                     WifiSavedNetwork {
                         ssid: "Work".to_string(),
-                        flags: "".to_string(),
+                        flags: String::new(),
                     },
                 ],
             };

--- a/src/backend/src/keycloak_client.rs
+++ b/src/backend/src/keycloak_client.rs
@@ -132,21 +132,21 @@ Y0282ogmR+NZiE25/g1ZBLkIDBuXU52hE2yKsO1VHf7ixbkxozNCt45XfzfNes9rH9swg4+sZWJ\
 
     const TOKEN_EXPIRE_HOURS: u64 = 2;
 
+    // Wrap TokenClaims with standard JWT fields
+    #[derive(Serialize)]
+    struct FullClaims<'a> {
+        iat: u64,
+        exp: u64,
+        #[serde(flatten)]
+        inner: &'a TokenClaims,
+    }
+
     fn sign_test_token(claims: &TokenClaims) -> String {
         let key = EncodingKey::from_rsa_pem(TEST_RSA_PRIVATE_KEY_PEM.as_bytes())
             .expect("test private key should parse");
 
         let iat = get_current_timestamp();
         let exp = iat + TOKEN_EXPIRE_HOURS * 3600;
-
-        // Wrap TokenClaims with standard JWT fields
-        #[derive(Serialize)]
-        struct FullClaims<'a> {
-            iat: u64,
-            exp: u64,
-            #[serde(flatten)]
-            inner: &'a TokenClaims,
-        }
 
         let full = FullClaims {
             iat,

--- a/src/backend/src/main.rs
+++ b/src/backend/src/main.rs
@@ -279,9 +279,7 @@ fn optimal_worker_count() -> usize {
     const MIN_WORKERS: usize = 2;
     const MAX_WORKERS: usize = 4;
 
-    let cpu_count = std::thread::available_parallelism()
-        .map(std::num::NonZero::get)
-        .unwrap_or(2);
+    let cpu_count = std::thread::available_parallelism().map_or(2, std::num::NonZero::get);
 
     // For I/O-bound workloads, use fewer workers than CPUs
     let workers = (cpu_count / 2).clamp(MIN_WORKERS, MAX_WORKERS);
@@ -593,6 +591,8 @@ mod tests {
 
     /// Build a test app mirroring production route + middleware layout.
     /// Uses stub handlers — we're testing auth enforcement, not handler logic.
+    // actix's test service uses Rc internally, so the returned future cannot be Send.
+    #[allow(clippy::future_not_send)]
     async fn create_route_auth_service() -> impl actix_service::Service<
         actix_http::Request,
         Response = ServiceResponse,

--- a/src/backend/src/middleware.rs
+++ b/src/backend/src/middleware.rs
@@ -209,9 +209,9 @@ pub mod tests {
         }
     }
 
-    fn generate_token(claim: TestClaims) -> String {
-        let key = EncodingKey::from_secret("test-secret-key!".as_bytes());
-        encode(&Header::default(), &claim, &key).unwrap()
+    fn generate_token(claim: &TestClaims) -> String {
+        let key = EncodingKey::from_secret(b"test-secret-key!");
+        encode(&Header::default(), claim, &key).unwrap()
     }
 
     async fn index() -> impl Responder {
@@ -230,6 +230,8 @@ pub mod tests {
         0x8, 0x15, 0xc9, 0xe0,
     ];
 
+    // actix's service types use Rc internally, so the returned future cannot be Send.
+    #[allow(clippy::future_not_send)]
     async fn create_service() -> impl actix_service::Service<
         actix_http::Request,
         Response = ServiceResponse,
@@ -270,10 +272,7 @@ pub mod tests {
         let ttl = actix_web::cookie::time::Duration::seconds(ttl.try_into().unwrap());
 
         let session_value = session_store
-            .save(
-                HashMap::from([(token_name, format!("\"{}\"", token))]),
-                &ttl,
-            )
+            .save(HashMap::from([(token_name, format!("\"{token}\""))]), &ttl)
             .await
             .unwrap()
             .as_ref()
@@ -287,7 +286,7 @@ pub mod tests {
     #[tokio::test]
     async fn middleware_correct_token_should_succeed() {
         let claim = generate_valid_claim();
-        let token = generate_token(claim);
+        let token = generate_token(&claim);
 
         let app = create_service().await;
         let cookie = create_cookie_for_token(&token).await;
@@ -304,7 +303,7 @@ pub mod tests {
     #[tokio::test]
     async fn middleware_expired_token_should_require_login() {
         let claim = generate_expired_claim();
-        let token = generate_token(claim);
+        let token = generate_token(&claim);
 
         let app = create_service().await;
         let cookie = create_cookie_for_token(&token).await;
@@ -321,7 +320,7 @@ pub mod tests {
     #[tokio::test]
     async fn middleware_token_with_invalid_subject_should_require_login() {
         let claim = generate_invalid_subject_claim();
-        let token = generate_token(claim);
+        let token = generate_token(&claim);
 
         let app = create_service().await;
         let cookie = create_cookie_for_token(&token).await;
@@ -335,7 +334,7 @@ pub mod tests {
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 
         let claim = generate_unset_subject_claim();
-        let token = generate_token(claim);
+        let token = generate_token(&claim);
 
         let app = create_service().await;
         let cookie = create_cookie_for_token(&token).await;
@@ -352,7 +351,7 @@ pub mod tests {
     #[tokio::test]
     async fn middleware_invalid_token_should_require_login() {
         let claim = generate_unset_subject_claim();
-        let _ = generate_token(claim);
+        let _ = generate_token(&claim);
         let token = "someinvalidtestbytes".to_string();
 
         let app = create_service().await;
@@ -417,7 +416,7 @@ pub mod tests {
     #[tokio::test]
     async fn middleware_correct_bearer_token_should_succeed() {
         let claim = generate_valid_claim();
-        let token = generate_token(claim);
+        let token = generate_token(&claim);
 
         let app = create_service().await;
 
@@ -433,7 +432,7 @@ pub mod tests {
     #[tokio::test]
     async fn middleware_bearer_auth_preserves_request_body() {
         let claim = generate_valid_claim();
-        let token = generate_token(claim);
+        let token = generate_token(&claim);
 
         let app = create_service().await;
 
@@ -483,7 +482,7 @@ pub mod tests {
     #[tokio::test]
     async fn verify_correct_token_should_succeed() {
         let claim = generate_valid_claim();
-        let token = generate_token(claim);
+        let token = generate_token(&claim);
         let token_manager = TokenManager::new("test-secret-key!");
 
         assert!(token_manager.verify_token(token.as_str()));
@@ -492,7 +491,7 @@ pub mod tests {
     #[tokio::test]
     async fn verify_expired_token_should_fail() {
         let claim = generate_expired_claim();
-        let token = generate_token(claim);
+        let token = generate_token(&claim);
         let token_manager = TokenManager::new("test-secret-key!");
 
         assert!(!token_manager.verify_token(token.as_str()));
@@ -501,13 +500,13 @@ pub mod tests {
     #[tokio::test]
     async fn verify_token_with_invalid_subject_should_fail() {
         let claim = generate_unset_subject_claim();
-        let token = generate_token(claim);
+        let token = generate_token(&claim);
         let token_manager = TokenManager::new("test-secret-key!");
 
         assert!(!token_manager.verify_token(token.as_str()));
 
         let claim = generate_invalid_subject_claim();
-        let token = generate_token(claim);
+        let token = generate_token(&claim);
 
         assert!(!token_manager.verify_token(token.as_str()));
     }
@@ -515,7 +514,7 @@ pub mod tests {
     #[tokio::test]
     async fn verify_token_with_invalid_token_should_fail() {
         let claim = generate_invalid_subject_claim();
-        let _ = generate_token(claim);
+        let _ = generate_token(&claim);
         let token = "someinvalidtestbytes".to_string();
         let token_manager = TokenManager::new("test-secret-key!");
 

--- a/src/backend/src/omnect_device_service_client.rs
+++ b/src/backend/src/omnect_device_service_client.rs
@@ -450,7 +450,7 @@ mod tests {
         #[test]
         fn detects_version_mismatch_when_below_requirement() {
             let status = create_test_status("0.38.0");
-            let current_version = status.system_info.omnect_device_service_version.clone();
+            let current_version = status.system_info.omnect_device_service_version;
 
             let required_version = OmnectDeviceServiceClient::required_version();
             let parsed_current = Version::parse(&current_version).unwrap();
@@ -463,7 +463,7 @@ mod tests {
         #[test]
         fn detects_no_mismatch_when_matching_requirement() {
             let status = create_test_status("0.40.0");
-            let current_version = status.system_info.omnect_device_service_version.clone();
+            let current_version = status.system_info.omnect_device_service_version;
 
             let required_version = OmnectDeviceServiceClient::required_version();
             let parsed_current = Version::parse(&current_version).unwrap();

--- a/src/backend/src/services/auth/session_key.rs
+++ b/src/backend/src/services/auth/session_key.rs
@@ -81,7 +81,7 @@ mod tests {
         let path = dir.path().join("session.key");
 
         // Write a known 64-byte key.
-        let original_bytes: Vec<u8> = (0..SESSION_KEY_LEN as u8).collect();
+        let original_bytes: Vec<u8> = (0..u8::try_from(SESSION_KEY_LEN).unwrap()).collect();
         std::fs::write(&path, &original_bytes).unwrap();
 
         let key = SessionKeyService::load_or_generate(&path);

--- a/src/backend/src/services/firmware.rs
+++ b/src/backend/src/services/firmware.rs
@@ -195,6 +195,9 @@ mod tests {
     // Note: Streaming tests would require mocking actix_multipart::Field which is complex.
     // Focusing on file system operations for now.
 
+    // Tests serialize access to the data folder via a std::sync::Mutex;
+    // holding it across .await is intentional to prevent parallel test interference.
+    #[allow(clippy::await_holding_lock)]
     mod clear_data_folder {
         use super::*;
 

--- a/src/backend/src/services/network.rs
+++ b/src/backend/src/services/network.rs
@@ -574,7 +574,7 @@ mod tests {
             let mut ini = Ini::new();
             ini.with_section(Some("Match".to_owned()))
                 .set("Name", &config.name);
-            let mut network_section = ini.with_section(Some("Network").to_owned());
+            let mut network_section = ini.with_section(Some("Network"));
             network_section.set("DHCP", "yes");
 
             let config_path = temp_dir.path().join("10-eth0.network");
@@ -609,18 +609,18 @@ mod tests {
             let mut ini = Ini::new();
             ini.with_section(Some("Match".to_owned()))
                 .set("Name", &config.name);
-            let mut network_section = ini.with_section(Some("Network").to_owned());
+            let mut network_section = ini.with_section(Some("Network"));
 
             let ip = config.ip.as_ref().expect("ip required for static");
             let mask = config.netmask.expect("mask required for static");
             network_section.set("Address", format!("{ip}/{mask}"));
 
             for gateway in &config.gateway {
-                network_section.add("Gateway", gateway.to_string());
+                network_section.add("Gateway", gateway.clone());
             }
 
             for dns in &config.dns {
-                network_section.add("DNS", dns.to_string());
+                network_section.add("DNS", dns.clone());
             }
 
             let config_path = temp_dir.path().join("10-eth0.network");

--- a/src/backend/tests/http_client.rs
+++ b/src/backend/tests/http_client.rs
@@ -23,9 +23,8 @@ async fn start_mock_unix_socket_server(
 
         tokio::spawn(async move {
             let mut reader = BufReader::new(&mut stream);
-            let mut _headers = Vec::new();
 
-            // Read HTTP headers
+            // Read and discard HTTP headers
             loop {
                 let mut line = String::new();
                 if reader.read_line(&mut line).await.is_err() {
@@ -35,8 +34,6 @@ async fn start_mock_unix_socket_server(
                 if line.trim().is_empty() {
                     break;
                 }
-
-                _headers.push(line);
             }
 
             // Simple mock response
@@ -92,6 +89,12 @@ async fn test_unix_socket_client_integration_success() {
     server_handle.abort();
 }
 
+#[derive(Serialize)]
+struct TestPayload {
+    name: String,
+    value: i32,
+}
+
 #[tokio::test]
 async fn test_unix_socket_client_integration_post_request() {
     // Create a temporary directory for the Unix socket
@@ -115,12 +118,6 @@ async fn test_unix_socket_client_integration_post_request() {
         .expect("failed to create unix socket client");
 
     // Make a POST request with JSON payload
-    #[derive(Serialize)]
-    struct TestPayload {
-        name: String,
-        value: i32,
-    }
-
     let payload = TestPayload {
         name: "test".to_string(),
         value: 42,

--- a/src/backend/tests/validate_portal_token.rs
+++ b/src/backend/tests/validate_portal_token.rs
@@ -6,6 +6,8 @@ use omnect_ui::{
     keycloak_client::SingleSignOnProvider, omnect_device_service_client::DeviceServiceClient,
 };
 
+// actix's test service uses Rc internally, so the returned future cannot be Send.
+#[allow(clippy::future_not_send)]
 async fn call_validate(
     api: Api<DeviceServiceClient, SingleSignOnProvider>,
 ) -> actix_web::dev::ServiceResponse {
@@ -26,7 +28,11 @@ fn make_claims(role: &str, tenant: &str, fleets: Option<Vec<&str>>) -> TokenClai
     TokenClaims {
         roles: Some(vec![role.to_string()]),
         tenant_list: Some(vec![tenant.to_string()]),
-        fleet_list: fleets.map(|fs| fs.into_iter().map(|f| f.to_string()).collect()),
+        fleet_list: fleets.map(|fs| {
+            fs.into_iter()
+                .map(std::string::ToString::to_string)
+                .collect()
+        }),
     }
 }
 
@@ -52,6 +58,7 @@ fn make_api(
     }
 }
 
+#[allow(clippy::future_not_send)]
 async fn assert_status(
     api: Api<DeviceServiceClient, SingleSignOnProvider>,
     expected: actix_web::http::StatusCode,


### PR DESCRIPTION
Address warnings surfaced by clippy under Rust 1.95:
- collapsible match guards in reconnection.rs
- sort_by_key with Reverse instead of sort_by closure
- redundant clones in tests and device service client
- String::new() instead of "".to_string()
- items_after_statements refactors
- pass-by-ref for generate_token; byte-literal and inline format args
- u8::try_from for SESSION_KEY_LEN cast
- implicit_clone fixes in network ini writing
- unused headers collection removed in http_client test

Annotate intentional exceptions:
- #[allow(clippy::future_not_send)] on actix test helpers (actix uses Rc internally, so the future cannot be Send)
- #[allow(clippy::await_holding_lock)] on firmware tests that intentionally serialize access to the data folder via std::sync::Mutex