### PR TITLE
feat(wifi): probe wifi-commissioning-service via /api/v1/service-info

### DIFF
--- a/src/app/src/types/wifi.rs
+++ b/src/app/src/types/wifi.rs
@@ -147,11 +147,6 @@ pub struct WifiForgetResponse {
     pub status: String,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
-pub struct WifiVersionResponse {
-    pub version: String,
-}
-
 /// Capabilities of the running wifi-commissioning-service instance
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct WifiServiceInfoResponse {

--- a/src/app/src/types/wifi.rs
+++ b/src/app/src/types/wifi.rs
@@ -1,3 +1,4 @@
+use super::update::VersionInfo;
 use serde::{Deserialize, Serialize};
 
 /// `WiFi` service availability info returned by the backend
@@ -10,8 +11,9 @@ pub enum WifiAvailability {
     },
     Unavailable {
         socket_present: bool,
-        version: Option<String>,
-        min_required_version: String,
+        /// `None` when the service could not be reached at all, so there is no
+        /// version to compare.
+        version_info: Option<VersionInfo>,
     },
 }
 
@@ -70,8 +72,7 @@ pub enum WifiState {
     Unknown,
     Unavailable {
         socket_present: bool,
-        version: Option<String>,
-        min_required_version: String,
+        version_info: Option<VersionInfo>,
     },
     Ready {
         interface_name: String,
@@ -148,5 +149,15 @@ pub struct WifiForgetResponse {
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct WifiVersionResponse {
+    pub version: String,
+}
+
+/// Capabilities of the running wifi-commissioning-service instance
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct WifiServiceInfoResponse {
+    pub status: String,
+    /// Live BLE transport state: `true` only once BLE actually started.
+    pub ble_enabled: bool,
+    pub interface_name: String,
     pub version: String,
 }

--- a/src/app/src/update/mod.rs
+++ b/src/app/src/update/mod.rs
@@ -101,8 +101,7 @@ mod tests {
             Event::Wifi(WifiEvent::CheckAvailabilityResponse(Ok(
                 WifiAvailability::Unavailable {
                     socket_present: false,
-                    version: None,
-                    min_required_version: "0.1.0".into(),
+                    version_info: None,
                 },
             ))),
             &mut model,

--- a/src/app/src/update/wifi.rs
+++ b/src/app/src/update/wifi.rs
@@ -88,13 +88,11 @@ pub fn handle(event: WifiEvent, model: &mut Model) -> Command<Effect, Event> {
             }
             Ok(WifiAvailability::Unavailable {
                 socket_present,
-                version,
-                min_required_version,
+                version_info,
             }) => {
                 model.wifi_state = WifiState::Unavailable {
                     socket_present,
-                    version,
-                    min_required_version,
+                    version_info,
                 };
                 render()
             }
@@ -102,8 +100,7 @@ pub fn handle(event: WifiEvent, model: &mut Model) -> Command<Effect, Event> {
                 log::error!("WiFi availability check failed: {e}");
                 model.wifi_state = WifiState::Unavailable {
                     socket_present: false,
-                    version: None,
-                    min_required_version: "0.1.0".to_string(), // Fallback
+                    version_info: None,
                 };
                 render()
             }
@@ -509,7 +506,7 @@ mod tests {
     use super::*;
     use crate::{
         EffectTestExt,
-        types::{WifiAvailability, WifiSavedNetwork},
+        types::{VersionInfo, WifiAvailability, WifiSavedNetwork},
     };
 
     fn model_with_ready_state() -> Model {
@@ -567,18 +564,38 @@ mod tests {
         #[test]
         fn check_availability_unavailable_response() {
             let mut model = Model::default();
+            let version_info = VersionInfo {
+                required: ">=0.2.1".to_string(),
+                current: "0.2.0".to_string(),
+                mismatch: true,
+            };
             let result = Ok(WifiAvailability::Unavailable {
                 socket_present: true,
-                version: Some("0.0.9".to_string()),
-                min_required_version: "0.1.0".to_string(),
+                version_info: Some(version_info.clone()),
             });
             let _ = handle(WifiEvent::CheckAvailabilityResponse(result), &mut model);
             assert_eq!(
                 model.wifi_state,
                 WifiState::Unavailable {
                     socket_present: true,
-                    version: Some("0.0.9".to_string()),
-                    min_required_version: "0.1.0".to_string()
+                    version_info: Some(version_info),
+                }
+            );
+        }
+
+        #[test]
+        fn unreachable_service_reports_no_version_info() {
+            let mut model = Model::default();
+            let result = Ok(WifiAvailability::Unavailable {
+                socket_present: true,
+                version_info: None,
+            });
+            let _ = handle(WifiEvent::CheckAvailabilityResponse(result), &mut model);
+            assert_eq!(
+                model.wifi_state,
+                WifiState::Unavailable {
+                    socket_present: true,
+                    version_info: None,
                 }
             );
         }
@@ -592,8 +609,7 @@ mod tests {
                 model.wifi_state,
                 WifiState::Unavailable {
                     socket_present: false,
-                    version: None,
-                    min_required_version: "0.1.0".to_string()
+                    version_info: None,
                 }
             );
         }

--- a/src/backend/src/main.rs
+++ b/src/backend/src/main.rs
@@ -289,10 +289,11 @@ fn optimal_worker_count() -> usize {
 }
 
 async fn initialize_wifi_client() -> (Option<WifiCommissioningServiceClient>, WifiAvailability) {
+    // No socket means the service is not installed at all, so there is no
+    // version to report.
     let unavailable = WifiAvailability::Unavailable {
         socket_present: false,
-        version: None,
-        min_required_version: WifiCommissioningServiceClient::MIN_REQUIRED_VERSION.to_string(),
+        version_info: None,
     };
 
     let config = &AppConfig::get().wifi;

--- a/src/backend/src/wifi_commissioning_client.rs
+++ b/src/backend/src/wifi_commissioning_client.rs
@@ -6,13 +6,14 @@ use log::info;
 #[cfg(feature = "mock")]
 use mockall::automock;
 pub use omnect_ui_core::types::{
-    WifiAvailability, WifiConnectRequest, WifiConnectResponse, WifiDisconnectResponse,
+    VersionInfo, WifiAvailability, WifiConnectRequest, WifiConnectResponse, WifiDisconnectResponse,
     WifiForgetRequest, WifiForgetResponse, WifiSavedNetworksResponse, WifiScanResultsResponse,
-    WifiScanStartedResponse, WifiStatusResponse, WifiVersionResponse,
+    WifiScanStartedResponse, WifiServiceInfoResponse, WifiStatusResponse, WifiVersionResponse,
 };
 use reqwest::Client;
+use semver::{Version, VersionReq};
 use serde::Serialize;
-use std::{fmt::Debug, path::Path};
+use std::{fmt::Debug, path::Path, sync::OnceLock};
 use trait_variant::make;
 
 // --- Client trait ---
@@ -28,6 +29,7 @@ pub trait WifiCommissioningClient {
     async fn saved_networks(&self) -> Result<WifiSavedNetworksResponse>;
     async fn forget_network(&self, request: WifiForgetRequest) -> Result<WifiForgetResponse>;
     async fn version(&self) -> Result<WifiVersionResponse>;
+    async fn service_info(&self) -> Result<WifiServiceInfoResponse>;
 }
 
 #[cfg(feature = "mock")]
@@ -53,71 +55,88 @@ impl WifiCommissioningServiceClient {
     const NETWORKS_ENDPOINT: &str = "/api/v1/networks";
     const FORGET_ENDPOINT: &str = "/api/v1/networks/forget";
     const VERSION_ENDPOINT: &str = "/api/v1/version";
+    const SERVICE_INFO_ENDPOINT: &str = "/api/v1/service-info";
 
-    pub const MIN_REQUIRED_VERSION: semver::Version = semver::Version::new(0, 1, 0);
+    // The floor is the oldest wifi-commissioning-service serving
+    // /api/v1/service-info, which is the availability probe used here.
+    const REQUIRED_CLIENT_VERSION: &str = ">=0.2.1";
+
+    fn required_version() -> &'static VersionReq {
+        static REQUIRED_VERSION: OnceLock<VersionReq> = OnceLock::new();
+        REQUIRED_VERSION.get_or_init(|| {
+            VersionReq::parse(Self::REQUIRED_CLIENT_VERSION)
+                .expect("invalid REQUIRED_CLIENT_VERSION constant")
+        })
+    }
+
+    /// A version that does not parse counts as a mismatch: it cannot be shown
+    /// to satisfy the requirement.
+    fn version_info(current: &str) -> VersionInfo {
+        let mismatch = match Version::parse(current) {
+            Ok(parsed) => !Self::required_version().matches(&parsed),
+            Err(e) => {
+                log::warn!("failed to parse WiFi service version '{current}': {e:#}");
+                true
+            }
+        };
+
+        VersionInfo {
+            required: Self::REQUIRED_CLIENT_VERSION.to_string(),
+            current: current.to_string(),
+            mismatch,
+        }
+    }
 
     pub async fn check_availability(&self) -> WifiAvailability {
-        let status_result = self.status().await;
-        let version_result = self.version().await;
-
-        match (status_result, version_result) {
-            (Ok(status), Ok(version_response)) => {
-                let is_version_compatible = match semver::Version::parse(&version_response.version)
-                {
-                    Ok(v) => v >= Self::MIN_REQUIRED_VERSION,
-                    Err(e) => {
-                        log::warn!(
-                            "Failed to parse WiFi service version '{}': {}",
-                            version_response.version,
-                            e
-                        );
-                        false
-                    }
+        // A service older than the floor has no /api/v1/service-info and answers
+        // 404, which lands here as an error — expected, not a fault.
+        let info = match self.service_info().await {
+            Ok(info) => info,
+            Err(e) => {
+                log::warn!("WiFi service-info probe failed: {e:#}");
+                return WifiAvailability::Unavailable {
+                    socket_present: true,
+                    version_info: None,
                 };
-
-                if is_version_compatible {
-                    log::info!(
-                        "WiFi service available (version {})",
-                        version_response.version
-                    );
-
-                    if let Some(interface_name) = status.interface_name {
-                        return WifiAvailability::Available {
-                            version: version_response.version,
-                            interface_name,
-                        };
-                    }
-                    log::error!("WiFi service reported OK status but no interface name");
-                } else {
-                    log::warn!(
-                        "WiFi service version '{}' is lower than required minimum {}",
-                        version_response.version,
-                        Self::MIN_REQUIRED_VERSION
-                    );
-                }
-
-                WifiAvailability::Unavailable {
-                    socket_present: true,
-                    version: Some(version_response.version),
-                    min_required_version: Self::MIN_REQUIRED_VERSION.to_string(),
-                }
             }
-            (Err(e), _) => {
-                log::error!("WiFi service status probe failed: {e:#}");
-                WifiAvailability::Unavailable {
-                    socket_present: true,
-                    version: None,
-                    min_required_version: Self::MIN_REQUIRED_VERSION.to_string(),
-                }
+        };
+
+        let version_info = Self::version_info(&info.version);
+
+        if version_info.mismatch {
+            log::warn!(
+                "WiFi service version '{}' does not satisfy {}",
+                info.version,
+                Self::REQUIRED_CLIENT_VERSION
+            );
+            return WifiAvailability::Unavailable {
+                socket_present: true,
+                version_info: Some(version_info),
+            };
+        }
+
+        if info.interface_name.is_empty() {
+            log::error!("WiFi service reported no interface name");
+            return WifiAvailability::Unavailable {
+                socket_present: true,
+                version_info: Some(version_info),
+            };
+        }
+
+        log::info!(
+            "WiFi service available (version {}, interface {}, BLE {})",
+            info.version,
+            info.interface_name,
+            if info.ble_enabled {
+                "enabled"
+            } else {
+                "disabled"
             }
-            (_, Err(e)) => {
-                log::error!("WiFi service version probe failed: {e:#}");
-                WifiAvailability::Unavailable {
-                    socket_present: true,
-                    version: None,
-                    min_required_version: Self::MIN_REQUIRED_VERSION.to_string(),
-                }
-            }
+        );
+
+        WifiAvailability::Available {
+            version: info.version,
+            interface_name: info.interface_name,
         }
     }
 
@@ -231,6 +250,11 @@ impl WifiCommissioningClient for WifiCommissioningServiceClient {
     async fn version(&self) -> Result<WifiVersionResponse> {
         let body = self.get(Self::VERSION_ENDPOINT).await?;
         serde_json::from_str(&body).context("failed to parse version response")
+    }
+
+    async fn service_info(&self) -> Result<WifiServiceInfoResponse> {
+        let body = self.get(Self::SERVICE_INFO_ENDPOINT).await?;
+        serde_json::from_str(&body).context("failed to parse service info response")
     }
 }
 
@@ -366,6 +390,72 @@ mod tests {
                 WifiCommissioningServiceClient::VERSION_ENDPOINT,
                 "/api/v1/version"
             );
+            assert_eq!(
+                WifiCommissioningServiceClient::SERVICE_INFO_ENDPOINT,
+                "/api/v1/service-info"
+            );
+        }
+    }
+
+    mod version_requirements {
+        use super::*;
+
+        #[test]
+        fn required_version_parses_correctly() {
+            let version_req = WifiCommissioningServiceClient::required_version();
+            assert_eq!(version_req.to_string(), ">=0.2.1");
+        }
+
+        #[test]
+        fn accepts_the_floor_and_newer() {
+            for current in ["0.2.1", "0.3.0", "1.0.0"] {
+                let info = WifiCommissioningServiceClient::version_info(current);
+                assert!(!info.mismatch, "{current} should satisfy the requirement");
+                assert_eq!(info.current, current);
+                assert_eq!(info.required, ">=0.2.1");
+            }
+        }
+
+        #[test]
+        fn rejects_versions_below_the_floor() {
+            // 0.2.0 introduced /api/v1/service-info, 0.1.0 has no such endpoint.
+            for current in ["0.2.0", "0.1.0"] {
+                let info = WifiCommissioningServiceClient::version_info(current);
+                assert!(
+                    info.mismatch,
+                    "{current} should not satisfy the requirement"
+                );
+            }
+        }
+
+        #[test]
+        fn unparseable_version_counts_as_mismatch() {
+            let info = WifiCommissioningServiceClient::version_info("not-a-version");
+            assert!(info.mismatch);
+            assert_eq!(info.current, "not-a-version");
+        }
+    }
+
+    mod service_info_response {
+        use super::*;
+
+        #[test]
+        fn deserializes_all_fields() {
+            let json =
+                r#"{"status":"ok","ble_enabled":true,"interface_name":"wlan0","version":"0.2.1"}"#;
+            let resp: WifiServiceInfoResponse = serde_json::from_str(json).unwrap();
+            assert_eq!(resp.status, "ok");
+            assert!(resp.ble_enabled);
+            assert_eq!(resp.interface_name, "wlan0");
+            assert_eq!(resp.version, "0.2.1");
+        }
+
+        #[test]
+        fn deserializes_with_ble_disabled() {
+            let json =
+                r#"{"status":"ok","ble_enabled":false,"interface_name":"wlan0","version":"0.2.1"}"#;
+            let resp: WifiServiceInfoResponse = serde_json::from_str(json).unwrap();
+            assert!(!resp.ble_enabled);
         }
     }
 }

--- a/src/backend/src/wifi_commissioning_client.rs
+++ b/src/backend/src/wifi_commissioning_client.rs
@@ -8,7 +8,7 @@ use mockall::automock;
 pub use omnect_ui_core::types::{
     VersionInfo, WifiAvailability, WifiConnectRequest, WifiConnectResponse, WifiDisconnectResponse,
     WifiForgetRequest, WifiForgetResponse, WifiSavedNetworksResponse, WifiScanResultsResponse,
-    WifiScanStartedResponse, WifiServiceInfoResponse, WifiStatusResponse, WifiVersionResponse,
+    WifiScanStartedResponse, WifiServiceInfoResponse, WifiStatusResponse,
 };
 use reqwest::Client;
 use semver::{Version, VersionReq};
@@ -28,7 +28,6 @@ pub trait WifiCommissioningClient {
     async fn status(&self) -> Result<WifiStatusResponse>;
     async fn saved_networks(&self) -> Result<WifiSavedNetworksResponse>;
     async fn forget_network(&self, request: WifiForgetRequest) -> Result<WifiForgetResponse>;
-    async fn version(&self) -> Result<WifiVersionResponse>;
     async fn service_info(&self) -> Result<WifiServiceInfoResponse>;
 }
 
@@ -54,11 +53,10 @@ impl WifiCommissioningServiceClient {
     const STATUS_ENDPOINT: &str = "/api/v1/status";
     const NETWORKS_ENDPOINT: &str = "/api/v1/networks";
     const FORGET_ENDPOINT: &str = "/api/v1/networks/forget";
-    const VERSION_ENDPOINT: &str = "/api/v1/version";
     const SERVICE_INFO_ENDPOINT: &str = "/api/v1/service-info";
 
-    // The floor is the oldest wifi-commissioning-service serving
-    // /api/v1/service-info, which is the availability probe used here.
+    // Tracks the released wifi-commissioning-service tag, not the oldest version
+    // that answers the probe. Raise it together with a released tag.
     const REQUIRED_CLIENT_VERSION: &str = ">=0.2.1";
 
     fn required_version() -> &'static VersionReq {
@@ -247,11 +245,6 @@ impl WifiCommissioningClient for WifiCommissioningServiceClient {
         serde_json::from_str(&body).context("failed to parse forget response")
     }
 
-    async fn version(&self) -> Result<WifiVersionResponse> {
-        let body = self.get(Self::VERSION_ENDPOINT).await?;
-        serde_json::from_str(&body).context("failed to parse version response")
-    }
-
     async fn service_info(&self) -> Result<WifiServiceInfoResponse> {
         let body = self.get(Self::SERVICE_INFO_ENDPOINT).await?;
         serde_json::from_str(&body).context("failed to parse service info response")
@@ -385,10 +378,6 @@ mod tests {
             assert_eq!(
                 WifiCommissioningServiceClient::FORGET_ENDPOINT,
                 "/api/v1/networks/forget"
-            );
-            assert_eq!(
-                WifiCommissioningServiceClient::VERSION_ENDPOINT,
-                "/api/v1/version"
             );
             assert_eq!(
                 WifiCommissioningServiceClient::SERVICE_INFO_ENDPOINT,

--- a/src/ui/src/components/device/DeviceInfoCore.vue
+++ b/src/ui/src/components/device/DeviceInfoCore.vue
@@ -43,9 +43,12 @@ const deviceInfo = computed(() => {
     if (viewModel.wifiState.type === 'ready') {
       infoMap.set('WiFi commissioning service version', viewModel.wifiState.version || 'unknown')
     } else if (viewModel.wifiState.type === 'unavailable' && viewModel.wifiState.socketPresent) {
-      const versionStr = viewModel.wifiState.version || 'unknown'
-      const minReq = viewModel.wifiState.minRequiredVersion
-      infoMap.set('WiFi commissioning service version', `${versionStr} (minimum required: ${minReq})`)
+      // No versionInfo means the service did not answer the probe at all.
+      const info = viewModel.wifiState.versionInfo
+      infoMap.set(
+        'WiFi commissioning service version',
+        info ? `${info.current} (required: ${info.required})` : 'unknown'
+      )
     }
   }
 

--- a/src/ui/src/composables/core/types.ts
+++ b/src/ui/src/composables/core/types.ts
@@ -200,9 +200,16 @@ export interface WifiSavedNetworkType {
 	flags: string
 }
 
+/** Shared by the omnect-device-service healthcheck and the WiFi service probe. */
+export interface VersionInfoType {
+	required: string
+	current: string
+	mismatch: boolean
+}
+
 export type WifiStateType =
 	| { type: 'unknown' }
-	| { type: 'unavailable', socketPresent: boolean, version: string | null, minRequiredVersion: string }
+	| { type: 'unavailable', socketPresent: boolean, versionInfo: VersionInfoType | null }
 	| {
 		type: 'ready'
 		interfaceName: string
@@ -246,7 +253,7 @@ export interface ViewModel {
 	updateManifest: UpdateManifest | null
 	timeouts: { waitOnlineTimeout: { nanos: number; secs: bigint } } | null
 	healthcheck: {
-		versionInfo: { required: string; current: string; mismatch: boolean }
+		versionInfo: VersionInfoType
 		updateValidationStatus: { status: string }
 		networkRollbackOccurred: boolean
 		updateValidationAcked: boolean
@@ -491,8 +498,13 @@ export function convertWifiState(state: WifiState): WifiStateType {
 		return {
 			type: 'unavailable',
 			socketPresent: s.socket_present,
-			version: s.version || null,
-			minRequiredVersion: s.min_required_version,
+			versionInfo: s.version_info
+				? {
+						required: s.version_info.required,
+						current: s.version_info.current,
+						mismatch: s.version_info.mismatch,
+					}
+				: null,
 		}
 	}
 	if (state instanceof WifiStateVariantready) {

--- a/src/ui/tests/device.spec.ts
+++ b/src/ui/tests/device.spec.ts
@@ -14,7 +14,7 @@ test.describe('Device Info', () => {
   }
 
   test('displays system info via WebSocket', async ({ page }) => {
-    await mockWifiAvailable(page, { state: 'unavailable', socket_present: false, version: null, min_required_version: "0.1.0" });
+    await mockWifiAvailable(page, { state: 'unavailable', socket_present: false, version_info: null });
     await setupAndLogin(page);
 
     const systemInfo = {
@@ -40,23 +40,34 @@ test.describe('Device Info', () => {
   });
 
   test('hides WiFi commissioning service version when socket is missing', async ({ page }) => {
-    await mockWifiAvailable(page, { state: 'unavailable', socket_present: false, version: null, min_required_version: "0.1.0" });
+    await mockWifiAvailable(page, { state: 'unavailable', socket_present: false, version_info: null });
     await setupAndLogin(page);
     await expect(page.getByText('WiFi commissioning service version')).not.toBeVisible();
   });
 
   test('displays WiFi commissioning service version with hint when incompatible', async ({ page }) => {
-    await mockWifiAvailable(page, { state: 'unavailable', socket_present: true, version: "0.0.9", min_required_version: "0.1.0" });
+    await mockWifiAvailable(page, {
+      state: 'unavailable',
+      socket_present: true,
+      version_info: { required: '>=0.2.1', current: '0.2.0', mismatch: true },
+    });
     await setupAndLogin(page);
     await expect(page.getByText('WiFi commissioning service version')).toBeVisible();
-    await expect(page.getByText('0.0.9 (minimum required: 0.1.0)')).toBeVisible();
+    await expect(page.getByText('0.2.0 (required: >=0.2.1)')).toBeVisible();
+  });
+
+  test('shows unknown version when the service does not answer the probe', async ({ page }) => {
+    await mockWifiAvailable(page, { state: 'unavailable', socket_present: true, version_info: null });
+    await setupAndLogin(page);
+    await expect(page.getByText('WiFi commissioning service version')).toBeVisible();
+    await expect(page.getByText('unknown', { exact: true })).toBeVisible();
   });
 
   test('displays WiFi commissioning service version without hint when compatible', async ({ page }) => {
-    await mockWifiAvailable(page, { state: 'available', version: "0.1.1", interface_name: "wlan0" });
+    await mockWifiAvailable(page, { state: 'available', version: "0.2.1", interface_name: "wlan0" });
     await setupAndLogin(page);
     await expect(page.getByText('WiFi commissioning service version')).toBeVisible();
-    await expect(page.getByText('0.1.1', { exact: true })).toBeVisible();
-    await expect(page.getByText('minimum required')).not.toBeVisible();
+    await expect(page.getByText('0.2.1', { exact: true })).toBeVisible();
+    await expect(page.getByText('required:')).not.toBeVisible();
   });
 });

--- a/src/ui/tests/wifi.spec.ts
+++ b/src/ui/tests/wifi.spec.ts
@@ -16,12 +16,11 @@ async function mockWifiAvailable(page: Page, available = true, interfaceName = '
       body: JSON.stringify(available ? {
         state: "available",
         interface_name: interfaceName,
-        version: "0.1.0"
+        version: "0.2.1"
       } : {
         state: "unavailable",
         socket_present: false,
-        version: "0.1.0",
-        min_required_version: "0.1.0"
+        version_info: null
       }),
     });
   });


### PR DESCRIPTION
## Summary

Uses `GET /api/v1/service-info` (wifi-commissioning-service 0.2.0, omnect/wifi-commissioning-service#3) as the single availability probe. It returns version, interface name and the live BLE state in one call, so the separate `status` and `version` requests are gone. The interface name also arrives as a plain string instead of an optional field on the status response. With nothing left calling it, the `/api/v1/version` probe and its response type are removed.

Reports the version requirement the same way as omnect-device-service does: a semver requirement string constant (`>=0.2.1`) resolved through a `OnceLock<VersionReq>`, and the same `VersionInfo { required, current, mismatch }` triple instead of the previous ad-hoc `min_required_version` string. `VersionInfo` is the existing type, reused. A version that does not parse counts as a mismatch.

`WifiAvailability::Unavailable` now carries `version_info: Option<VersionInfo>`. `None` means the service could not be reached at all, so there is no version to compare — that case shows as `unknown` in the device info instead of inventing a version.

A stale wifi-commissioning-service does not block the UI the way a stale omnect-device-service does. WiFi is optional and already gated on the socket being present, so the mismatch appears in the WiFi line of the device info and the rest of the app keeps working.

`ble_enabled` is parsed and logged only. Nothing consumes it yet, and putting it in the ViewModel would add bincode surface and regenerated bindings for no reader.

## Reason

The previous probe needed two round trips and read the interface name from `status`, where it is optional and had to be handled as a possible `None` even on a healthy service. `service-info` answers all of it at once.

The version check existed but was shaped differently from the omnect-device-service one: a bare `semver::Version` compared with `>=`, and a `min_required_version` string that only the WiFi code understood. Sharing the requirement-string plus `VersionInfo` shape means both services report an unsupported version through the same structure, and the floor is expressed as a semver requirement that can be widened later without touching the comparison.

The floor is `>=0.2.1`, the current wifi-commissioning-service release. `service-info` itself landed in 0.2.0; 0.2.1 only adds a BLE adapter retry and no API change, so a device on 0.2.0 would technically serve the probe — the floor tracks the released tag rather than the oldest version that happens to answer, and the constant's comment says so.